### PR TITLE
changed test structs to use rmse

### DIFF
--- a/@Tester/Tester.m
+++ b/@Tester/Tester.m
@@ -21,12 +21,12 @@ classdef Tester < handle
 
     function test_struct(self, StructA, StructB, testDescription)
       self.increment_test_count
-      if isequal(StructA, StructB)
+      if self.all_struct_fields_same(StructA, StructB)
         self.increment_fail_count
-        testResult = ' - structs match';
+        testResult = ' - Structs Match';
       else
         self.increment_pass_count
-        testResult = ' - structs don''t match';
+        testResult = ' - Structs Don''t Match';
         StructA
         StructB
       end
@@ -41,6 +41,18 @@ classdef Tester < handle
         testResult = ' PASSED';
         self.increment_pass_count
       end
+    end
+
+    function allTheSame = all_struct_fields_same(self, StructA, StructB)
+      fields = fieldnames(StructA);
+      for i = 1:numel(fields)
+        fieldName = fields{i};
+        valueA = StructA.(fieldName);
+        valueB = StructB.(fieldName);
+        rmse = self.compute_rmse(valueA, valueB);
+        results(i) = rmse <= self.tolerance;
+      end
+      allTheSame = all(results);
     end
 
     function increment_test_count(self)

--- a/docs/tester.md
+++ b/docs/tester.md
@@ -36,7 +36,7 @@ Test similar matrices FAILED | RMSE:5e-11
 
 That output is telling us that the Root mean square error between the two matrices is `5e-11` which is greater than the tolerance of the tester class.
 
-When testing structs a simple `isequal` is used and the structs are displayed if they are not the same. I'm sure this rudimentary implementation could be improved upon.
+When testing structs, rmse is calculated for each field. This is a rudimentary implementation and messaging could be improved upon.
 
 ### run_tests
 


### PR DESCRIPTION
Old version used `isequal` but that was failing on identical structs due to 18th digit round off error. Annoying! This version does the same rmse comparison as `test` but does an `all` to see that all elements of the struct passed.
